### PR TITLE
Add Monitor Priority to onBlockBreak()

### DIFF
--- a/src/david/miningrewards/EventListener.php
+++ b/src/david/miningrewards/EventListener.php
@@ -26,6 +26,8 @@ class EventListener implements Listener {
 
     /**
      * @param BlockBreakEvent $event
+     *
+     * @priority MONITOR
      */
     public function onBlockBreak(BlockBreakEvent $event) {
         if($event->isCancelled()) {


### PR DESCRIPTION
To ensure that world protection plugins (ie WorldProtect, iProtector) have a chance to cancel the block break event, before MiningRewards gives a reward to the player, an event priority of "MONITOR" has been added.

MONITOR was chosen because MiningRewards does not modify the BlockBreakEvent in any way and the MONITOR priority will ensure that all world protection listeners have been called before MiningRewards.

Fixes #5 and fixes #9 

For those that want to test this, you can download the plugin with this update from poggit at this link:

https://poggit.pmmp.io/r/57385/MiningRewards_pr-2.phar