### PR TITLE
Add Priority to onBlockBreak

### DIFF
--- a/src/david/miningrewards/EventListener.php
+++ b/src/david/miningrewards/EventListener.php
@@ -26,6 +26,7 @@ class EventListener implements Listener {
 
     /**
      * @param BlockBreakEvent $event
+     * @priority MONITOR
      */
     public function onBlockBreak(BlockBreakEvent $event) {
         if($event->isCancelled()) {


### PR DESCRIPTION
This adds `MONITOR` priority to `EventListener:onBlockBreak()` to ensure that area protection plugins have a chance to cancel the event before MiningRewards gives players a reward.